### PR TITLE
#22 redirect to own domain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   #herokuapp.comから独自ドメインへリダイレクト
-  before_filter :ensure_domain
-  FQDN = 'www.find-hiramasa.com'
+  before_action :ensure_domain
+  FQDN = 'find-hiramasa.com'
  
   # redirect correct server from herokuapp domain for SEO
   def ensure_domain

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,14 @@
 class ApplicationController < ActionController::Base
+  #herokuapp.comから独自ドメインへリダイレクト
+  before_filter :ensure_domain
+  FQDN = 'www.find-hiramasa.com'
+ 
+  # redirect correct server from herokuapp domain for SEO
+  def ensure_domain
+   return unless /\.herokuapp.com/ =~ request.host
+   
+   # 主にlocalテスト用の対策80と443以外でアクセスされた場合ポート番号をURLに含める 
+   port = ":#{request.port}" unless [80, 443].include?(request.port)
+   redirect_to "#{request.protocol}#{FQDN}#{port}#{request.path}", status: :moved_permanently
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   #herokuapp.comから独自ドメインへリダイレクト
   before_action :ensure_domain
-  FQDN = 'find-hiramasa.com'
+  FQDN = 'www.find-hiramasa.com'
  
   # redirect correct server from herokuapp domain for SEO
   def ensure_domain

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
herokuのurlから遷移した場合、独自urlにリダイレクトされるように設定

* herokuapp.comの場合、www.find-hiramasa.comにリダイレクト
* httpの場合、httpsにリダイレクト